### PR TITLE
Use image crate to save renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 *.P3
 *.P3*
 *.ppm
+renders

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trt"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Afnan Enayet <afnan.enayet@gmail.com>"]
 
 [lib]

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,12 +47,25 @@ I'm also using [nalgebra](http://nalgebra.org) as my linear algebra library.
 
 To run tests:
 
-    cargo test
+```sh
+cargo test
+```
 
 To build:
 
-    RUSTFLAGS="-C target-cpu=native" cargo build --release
+```sh
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+```
 
 To run:
 
-    RUSTFLAGS="-C target-cpu=native" cargo run --release
+```sh
+RUSTFLAGS="-C target-cpu=native" cargo run --release
+```
+
+In order for the renderer to be able to output images, you will need to
+create the output folder, otherwise it will panic and fail.
+
+```sh
+mkdir renders
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,8 @@ fn color(r: &Ray3f, primitives: &HitList<f32>, depth: u32, depth_limit: u32) -> 
 }
 
 fn main() -> std::io::Result<()> {
-    let nx = 1920; // width
-    let ny = 1080; // height
+    let nx = 200; // width
+    let ny = 100; // height
     let ns = 200; // antialiasing factor
 
     // initialize scene objects
@@ -167,7 +167,7 @@ fn main() -> std::io::Result<()> {
     // flatten the image buffer so it can be saved using the image crate
     let image_buffer: Vec<u8> = buffer.iter().flat_map(|n| n.iter().cloned()).collect();
     image::save_buffer(
-        "render.png",
+        "renders/render.png",
         &image_buffer,
         nx as u32,
         ny as u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use rand::{thread_rng, Rng};
 use rayon::iter::IntoParallelIterator;
 use rayon::prelude::*;
 use std::default::Default;
+use std::fs;
+use std::path::Path;
 use std::time::Instant;
 use std::vec::Vec;
 use trtlib::camera::pinhole::Pinhole;
@@ -20,6 +22,14 @@ use trtlib::material::mirror::Mirror;
 use trtlib::material::BSDF;
 use trtlib::primitives::sphere::Sphere;
 use trtlib::typedefs::*;
+
+/// Create the render/output directory if it doesn't already exist. If it does, do nothing.
+fn create_render_dir(dir: &str) -> std::io::Result<()> {
+    if !Path::new(dir).exists() {
+        fs::create_dir(dir)?
+    }
+    Ok(())
+}
 
 /// Constructs the objects in the scene and returns a vector populated by those objects.
 fn scene() -> HitList<f32> {
@@ -165,7 +175,9 @@ fn main() -> std::io::Result<()> {
     let start_time = Instant::now();
 
     // flatten the image buffer so it can be saved using the image crate
+    // Note that this is a performance issue as it doubles the memory necessary
     let image_buffer: Vec<u8> = buffer.iter().flat_map(|n| n.iter().cloned()).collect();
+    create_render_dir("renders")?;
     image::save_buffer(
         "renders/render.png",
         &image_buffer,


### PR DESCRIPTION
* move all logic used to save image to disk to render crate
  * uses less disk space because of compression
  * makes saving to disk much faster
* have a `renders` directory for all output from the ray tracer
  * easier to manage
  * update .gitignore to reflect this change
  * update main function to reflect this change